### PR TITLE
Fix sort order of kunnat

### DIFF
--- a/milloin-kutsunnat-sivut/src/components/form.tsx
+++ b/milloin-kutsunnat-sivut/src/components/form.tsx
@@ -15,9 +15,11 @@ type KutsunnatType = {
 
 const Form = () => {
     const kutsunnat: KutsunnatType = kutsunnatData;
-    const kunnat: OptionType[] = Object.keys(kutsunnat).map((k: string) => ({
-        value: k,
-        label: k.charAt(0).toUpperCase() + k.slice(1).toLowerCase(),
+    const kunnat: OptionType[] = Object.keys(kutsunnat)
+        .sort((a, b) => a.localeCompare(b, "fi"))
+        .map((k: string) => ({
+            value: k,
+            label: k.charAt(0).toUpperCase() + k.slice(1).toLowerCase(),
     }));
     const kielet: OptionType[] = [
         { value: "suomi", label: "Suomen kieli" },


### PR DESCRIPTION
I saw your LinkedIn post and took a look, what a great little tool, but noticed the sort order of municipalities was not alphabetical, so here's a fix.

I was also tempted to add tests, but let's keep it simple, so only tested with `npm run dev` and manually testing :) 

Cheers!